### PR TITLE
Hotfixes not pulling pages in production for building

### DIFF
--- a/lib/sanity.js
+++ b/lib/sanity.js
@@ -6,7 +6,7 @@ import {
   createCurrentUserHook,
 } from "next-sanity";
 
-const config = {
+let config = {
   /**
    * Find your project ID and dataset in `sanity.json` in your studio project.
    * These are considered “public”, but you can use environment variables
@@ -17,12 +17,21 @@ const config = {
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "production",
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "9itgab5x",
   useCdn: process.env.NODE_ENV === "production",
+
   /**
    * Set useCdn to `false` if your application require the freshest possible
    * data always (potentially slightly slower and a bit more expensive).
    * Authenticated request (like preview) will always bypass the CDN
    **/
 };
+
+// Require READ token when in production since `dataset` is set to `private`
+if (process.env.NODE_ENV === "production") {
+  config = {
+    ...config,
+    token: process.env.NEXT_PUBLIC_SANITY_API_READ_TOKEN,
+  };
+}
 
 /**
  * Set up a helper function for generating Image URLs with only the asset reference data in your documents.


### PR DESCRIPTION
All new created DXP studio's `dataset` is set to `private`. This means we'll have to pass in Sanity read token in order to pull data from Sanity and build the pages.