### PR TITLE
Fix Blog page errors when adding image to block content

### DIFF
--- a/component/blog/index.js
+++ b/component/blog/index.js
@@ -1,9 +1,8 @@
 import React from "react";
 import Head from "next/head";
-import { urlFor, usePreviewSubscription } from "lib/sanity";
+import { urlFor, usePreviewSubscription, PortableText } from "lib/sanity";
 import { blogQuery } from "pages/api/query";
 import { format } from "date-fns";
-import BlockContent from "@sanity/block-content-to-react";
 import PageNotFound from "pages/404";
 import dynamic from "next/dynamic";
 
@@ -202,7 +201,7 @@ function BlogPage({ data, preview, navAndFooter }) {
         <div className="container mx-auto px-4">
           {body && (
             <div className="max-w-4xl mx-auto">
-              <BlockContent blocks={body} serializers={blockStyle} />
+              <PortableText blocks={body} serializers={blockStyle} />
             </div>
           )}
         </div>


### PR DESCRIPTION
Adding image to post body of block content type:

![Screen Shot 2021-11-04 at 1 19 17 PM](https://user-images.githubusercontent.com/78787873/140262054-cff16f4f-d141-4711-8ad5-2a277a45c24a.png)

Renders similar error message on Blog page:

![Screen Shot 2021-11-04 at 1 20 31 PM](https://user-images.githubusercontent.com/78787873/140262126-2f5e7068-836f-44c4-bce8-6edbb8640204.png)