### PR TITLE
Hotfix release for 0.10.0 fixing blank white screen

### DIFF
--- a/component/sections/app_promo/index.js
+++ b/component/sections/app_promo/index.js
@@ -8,7 +8,7 @@ const Variants = {
 };
 
 function AppPromo({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/blog/index.js
+++ b/component/sections/blog/index.js
@@ -9,7 +9,7 @@ const Variants = {
 };
 
 function Blog({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/call_to_action/index.js
+++ b/component/sections/call_to_action/index.js
@@ -9,7 +9,7 @@ const Variants = {
 };
 
 function CallToAction({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/contact/index.js
+++ b/component/sections/contact/index.js
@@ -7,7 +7,7 @@ const Variants = {
 };
 
 function Contact({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/cookies/index.js
+++ b/component/sections/cookies/index.js
@@ -11,7 +11,7 @@ const Variants = {
 };
 
 function Cookies({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/faqs/index.js
+++ b/component/sections/faqs/index.js
@@ -8,7 +8,7 @@ const Variants = {
 };
 
 function FAQs({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/features/index.js
+++ b/component/sections/features/index.js
@@ -13,7 +13,7 @@ const Variants = {
 };
 
 function Features({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/footer/index.js
+++ b/component/sections/footer/index.js
@@ -8,7 +8,7 @@ const Variants = {
 };
 
 function Footer({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/hero/index.js
+++ b/component/sections/hero/index.js
@@ -10,7 +10,7 @@ const Variants = {
 };
 
 function Header({ template, data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/how_it_works/index.js
+++ b/component/sections/how_it_works/index.js
@@ -10,7 +10,7 @@ const Variants = {
 };
 
 function HowItWorks({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/logoCloud/index.js
+++ b/component/sections/logoCloud/index.js
@@ -9,7 +9,7 @@ const Variants = {
 };
 
 function LogoCloud({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/navigation/index.js
+++ b/component/sections/navigation/index.js
@@ -9,7 +9,7 @@ const Variants = {
 };
 
 function Navigation({ template, data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/newsletter/index.js
+++ b/component/sections/newsletter/index.js
@@ -7,7 +7,7 @@ const Variants = {
 };
 
 function Newsletter({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/portfolio/index.js
+++ b/component/sections/portfolio/index.js
@@ -9,7 +9,7 @@ const Variants = {
 };
 
 function Portfolio({ template, data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/pricing/index.js
+++ b/component/sections/pricing/index.js
@@ -11,7 +11,7 @@ const Variants = {
 const { NEXT_PUBLIC_DXP_STUDIO_ADDRESS } = process.env;
 
 function Pricing({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/sign_in_sign_up/index.js
+++ b/component/sections/sign_in_sign_up/index.js
@@ -7,7 +7,7 @@ const Variants = {
 };
 
 function SignUpForm({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/stats/index.js
+++ b/component/sections/stats/index.js
@@ -8,7 +8,7 @@ const Variants = {
 };
 
 function Stats({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/team/index.js
+++ b/component/sections/team/index.js
@@ -9,7 +9,7 @@ const Variants = {
 };
 
 function Team({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/testimonials/index.js
+++ b/component/sections/testimonials/index.js
@@ -9,7 +9,7 @@ const Variants = {
 };
 
 function Testimonial({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {

--- a/component/sections/text_component/index.js
+++ b/component/sections/text_component/index.js
@@ -8,7 +8,7 @@ const Variants = {
 };
 
 function TextComponent({ data }) {
-  const variant = data?.variant;
+  const variant = data?.variant || data?.variants?.condition;
   const Variant = Variants?.[variant];
 
   const props = {


### PR DESCRIPTION
- Add fallback for variant value on old data structure looking for `condition` key inside `variants` for backwards compatibility. The new data structure adds a `variant` at top level while retaining all the values of variants, eg: `variant_a`, `variant_b`, so on, inside the `variants` key.