### PR TITLE
Show corresponding page for never published page

### DIFF
--- a/pages/api/query.js
+++ b/pages/api/query.js
@@ -85,7 +85,7 @@ export const homeQuery = groq`
 `;
 
 export const slugQuery = groq`
-  *[_type == "page" && slug.current == $slug][0] ${allProjections}
+  *[_type == "page" && slug.current == $slug] ${allProjections}
 `;
 
 export const blogQuery = groq`

--- a/pages/no-preview.js
+++ b/pages/no-preview.js
@@ -1,15 +1,22 @@
 import React from "react";
+import Image from "next/image";
+import Link from "next/link";
 
 function NoPreview() {
   return (
-    <section className="bg-gray-50">
+    <section>
       <div className="py-20">
-        <div className="container mx-auto px-4">
-          <img
-            className="mx-auto"
-            src="https://cdn.sanity.io/images/9itgab5x/production/8f90c590ada0a2f3c89c35535c323320627b9622-554x312.png"
-            alt=""
-          />
+        <div className="container mx-auto px-4 text-center">
+          <div className="mx-auto">
+            <Image
+              layout="responsive"
+              width={854}
+              height={312}
+              objectFit="contain"
+              src="https://cdn.sanity.io/images/9itgab5x/production/8f90c590ada0a2f3c89c35535c323320627b9622-554x312.png"
+              alt="no-preview-image"
+            />
+          </div>
           <div className="text-center">
             <span className="mb-6 text-4xl text-webriq-darkblue font-bold">
               Whoops!
@@ -18,14 +25,13 @@ function NoPreview() {
               Publish your page first to preview LIVE site
             </p>
             <div>
-              <a
-                className="w-full lg:w-auto mb-2 lg:mb-0 lg:mr-4 inline-block py-2 px-6 rounded-l-xl rounded-t-xl font-bold leading-loose text-white bg-webriq-darkblue hover:bg-webriq-blue"
-                href="/"
-              >
-                Go back to Homepage
-              </a>
+              <Link href="/">
+                <a className="w-full lg:w-auto mb-2 lg:mb-0 lg:mr-4 inline-block py-2 px-6 rounded-l-xl rounded-t-xl font-bold leading-loose text-white bg-webriq-darkblue hover:bg-webriq-blue">
+                  Go back to Homepage
+                </a>
+              </Link>
               <button
-                className="w-full lg:w-auto inline-block py-2 px-6 rounded-l-xl rounded-t-xl font-bold leading-loose bg-white hover:bg-gray-50"
+                className="w-full lg:w-auto inline-block py-2 px-6 rounded-l-xl rounded-t-xl font-bold leading-loose bg-white hover:bg-gray-100"
                 onClick={() => window.location.reload(true)}
               >
                 Try Again

--- a/pages/no-preview.js
+++ b/pages/no-preview.js
@@ -1,0 +1,41 @@
+import React from "react";
+
+function NoPreview() {
+  return (
+    <section className="bg-gray-50">
+      <div className="py-20">
+        <div className="container mx-auto px-4">
+          <img
+            className="mx-auto"
+            src="https://cdn.sanity.io/images/9itgab5x/production/8f90c590ada0a2f3c89c35535c323320627b9622-554x312.png"
+            alt=""
+          />
+          <div className="text-center">
+            <span className="mb-6 text-4xl text-webriq-darkblue font-bold">
+              Whoops!
+            </span>
+            <p className="my-8 text-gray-700">
+              Publish your page first to preview LIVE site
+            </p>
+            <div>
+              <a
+                className="w-full lg:w-auto mb-2 lg:mb-0 lg:mr-4 inline-block py-2 px-6 rounded-l-xl rounded-t-xl font-bold leading-loose text-white bg-webriq-darkblue hover:bg-webriq-blue"
+                href="/"
+              >
+                Go back to Homepage
+              </a>
+              <button
+                className="w-full lg:w-auto inline-block py-2 px-6 rounded-l-xl rounded-t-xl font-bold leading-loose bg-white hover:bg-gray-50"
+                onClick={() => window.location.reload(true)}
+              >
+                Try Again
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default React.memo(NoPreview);


### PR DESCRIPTION
For new pages that have never been published, a 404 page is returned whenever a user will attempt to Open Preview. 
To fix this, show a pre-page that will let the user know that the page should be published first to preview. 