### PR TITLE
hotfixes image uploads that crashes the web preview

### DIFF
--- a/lib/sanity.js
+++ b/lib/sanity.js
@@ -15,10 +15,10 @@ export const imageBuilder = createImageUrlBuilder(config);
  * Read more: https://www.sanity.io/docs/image-url
  **/
 export const urlFor = (source) =>
-  imageBuilder.image(source).format("webp").url();
+  source?.asset && imageBuilder.image(source).format("webp")?.url();
 
 export const seoImageUrl = (source) =>
-  imageBuilder.image(source).format("jpg").url();
+  source?.asset && imageBuilder.image(source).format("jpg")?.url();
 
 // Set up the live preview subscription hook
 export const usePreviewSubscription = createPreviewSubscriptionHook(config);


### PR DESCRIPTION
This fixes web preview crashes when you upload a new image. The `asset` in `source` is initially not present making it incomplete data for the function to process, so we make sure to check that it's there before our function can properly function.

![image](https://user-images.githubusercontent.com/977413/193509477-7269a588-e73d-4ef5-9758-f899e51d3cb6.png)
