### PR TITLE
Improvements on duplicate page action

### DIFF
--- a/studio/components/actions/DialogFooter.tsx
+++ b/studio/components/actions/DialogFooter.tsx
@@ -189,10 +189,10 @@ export default function DialogFooter({ page, title, sections, dialogFn, values, 
 function SetDupePageSlug(allPages, currentPageTitle) {
   let duplicatePageTitle = currentPageTitle?.replace(/[^a-z0-9 ]/gi, "")?.replace(/\s+/g, "-");
 
-  if(!allPages?.find((page) => page?.title?.toLowerCase() === currentPageTitle?.toLowerCase())) {
+  if(!allPages?.some((page) => page?.title?.toLowerCase() === currentPageTitle?.toLowerCase())) {
     return duplicatePageTitle?.toLowerCase();
   } else {
-    duplicatePageTitle = `${duplicatePageTitle}-${nanoid()}`
+    duplicatePageTitle = `${duplicatePageTitle}-${nanoid(5)}`
     
     return duplicatePageTitle?.toLowerCase();
   }

--- a/studio/components/actions/DialogFooter.tsx
+++ b/studio/components/actions/DialogFooter.tsx
@@ -8,7 +8,7 @@ export default function DialogFooter({ page, title, sections, dialogFn, values }
   const [isLoading, setIsLoading] = useState(false);
 
   const document = values?.page || page;
-  const pageTitle = values?.title || title;
+  const pageTitle = values?.title || `Copy of ${title}`;
   const pageSections = values?.sections || sections;
   const setDialogOpen = values?.dialogFn || dialogFn;
   const isReadyForDuplicate = pageSections?.filter((section) => section.include)?.length !== 0

--- a/studio/components/actions/DialogFooter.tsx
+++ b/studio/components/actions/DialogFooter.tsx
@@ -12,7 +12,7 @@ export default function DialogFooter({ page, title, sections, dialogFn, values, 
   const pageTitle = values?.title || `Copy of ${title}`;
   const pageSections = values?.sections || sections;
   const setDialogOpen = values?.dialogFn || dialogFn;
-  const isReadyForDuplicate = pageSections?.filter((section) => section.include)?.length !== 0
+  const isReadyForDuplicate = pageSections?.filter((section) => section?.include)?.length !== 0
 
   // DUPLICATE DOCUMENT
   const handleDuplicateBtn = async (payload: any) => {

--- a/studio/components/actions/DialogFooter.tsx
+++ b/studio/components/actions/DialogFooter.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Flex, Inline, useToast, Popover, Stack, Text } from "@sani
 import { nanoid } from "nanoid";
 import { sanityClient } from "lib/sanity.client";
 
-export default function DialogFooter({ page, title, sections, dialogFn, values, setValues, allPages }) {
+export default function DialogFooter({ page, title, sections, dialogFn, values, setValues }) {
   const toast = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
@@ -156,10 +156,11 @@ export default function DialogFooter({ page, title, sections, dialogFn, values, 
             fontSize={2}
             padding={3}
             text="Duplicate"
-            onClick={() => handleDuplicateBtn({ 
+            onClick={() => handleDuplicateBtn({
+              _id: "drafts.", // to auto-generate a draft document ID 
               title: pageTitle, 
               slug: {
-                current: SetDupePageSlug(allPages, pageTitle),
+                current: pageTitle?.replace(/[^a-z0-9 ]/gi, "")?.replace(/\s+/g, "-")?.toLowerCase(),
                 _type: "slug"
               }, 
               _type: document?._type,
@@ -184,16 +185,4 @@ export default function DialogFooter({ page, title, sections, dialogFn, values, 
       </Box>
     </Flex>
   )
-}
-
-function SetDupePageSlug(allPages, currentPageTitle) {
-  let duplicatePageTitle = currentPageTitle?.replace(/[^a-z0-9 ]/gi, "")?.replace(/\s+/g, "-");
-
-  if(!allPages?.some((page) => page?.title?.toLowerCase() === currentPageTitle?.toLowerCase())) {
-    return duplicatePageTitle?.toLowerCase();
-  } else {
-    duplicatePageTitle = `${duplicatePageTitle}-${nanoid(5)}`
-    
-    return duplicatePageTitle?.toLowerCase();
-  }
 }

--- a/studio/components/actions/DialogFooter.tsx
+++ b/studio/components/actions/DialogFooter.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, Button, Flex, useToast } from "@sanity/ui";
+import { Box, Button, Flex, Inline, useToast } from "@sanity/ui";
 import { nanoid } from "nanoid";
 import { sanityClient } from "lib/sanity.client";
 
@@ -10,7 +10,8 @@ export default function DialogFooter({ page, title, sections, dialogFn, values }
   const document = values?.page || page;
   const pageTitle = values?.title || title;
   const pageSections = values?.sections || sections;
-  const setDialogOpen = values?.dialogFn || dialogFn; 
+  const setDialogOpen = values?.dialogFn || dialogFn;
+  const isReadyForDuplicate = pageSections?.filter((section) => section.include)?.length !== 0 && pageSections?.filter((section) => !section?.ready)?.length === 0
 
   // DUPLICATE DOCUMENT
   const handleDuplicateBtn = async (payload: any) => {
@@ -84,6 +85,11 @@ export default function DialogFooter({ page, title, sections, dialogFn, values }
     }
   }
 
+  console.log({
+    title: pageTitle,
+    sections: pageSections
+  })
+
   return (
     <Flex justify="space-between">
       <p className="ml-4 text-sm text-gray-500">
@@ -91,34 +97,49 @@ export default function DialogFooter({ page, title, sections, dialogFn, values }
         section/s to duplicate
       </p>
       <Box style={{ textAlign: "right" }}>
-        {/* Duplicate button */}
-        <Button
-          fontSize={2}
-          padding={3}
-          text="Duplicate"
-          onClick={() => handleDuplicateBtn({ 
-            title: pageTitle, 
-            slug: {
-              current: pageTitle?.replace(/[^a-z0-9 ]/gi, "")?.replace(/\s+/g, "-")?.toLowerCase(),
-              _type: "slug"
-            }, 
-            _type: document?._type,
-            sections: pageSections?.filter((section) => section?.include)?.map((section) => (
-              {
-                ...section, 
-                _type: section?._type === "pages_productInfo" ? "productInfo" : section?._type
-              }
-            )),
-            seo: document?.seo
-          })}
-          loading={isLoading}
-          disabled={!pageTitle || pageSections?.filter((section) => section.include)?.length === 0}
-          style={{ 
-            backgroundColor: !pageTitle || pageSections?.filter((section) => section.include)?.length === 0 ? "#d5e3ff" : "#0045d8", 
-            boxShadow: "unset", 
-            marginRight: "10px" 
-          }}
-        />
+        <Inline space={2}>
+          {/* Close dialog */}
+          <Button
+            fontSize={2}
+            padding={3}
+            text="Cancel"
+            onClick={() => setDialogOpen(false)}
+            style={{ 
+              backgroundColor: "red", 
+              boxShadow: "unset", 
+              marginRight: "10px" 
+            }}
+          />
+
+          {/* Duplicate button */}
+          <Button
+            fontSize={2}
+            padding={3}
+            text="Duplicate"
+            onClick={() => handleDuplicateBtn({ 
+              title: pageTitle, 
+              slug: {
+                current: pageTitle?.replace(/[^a-z0-9 ]/gi, "")?.replace(/\s+/g, "-")?.toLowerCase(),
+                _type: "slug"
+              }, 
+              _type: document?._type,
+              sections: pageSections?.filter((section) => section?.include)?.map((section) => (
+                {
+                  ...section, 
+                  _type: section?._type === "pages_productInfo" ? "productInfo" : section?._type
+                }
+              )),
+              seo: document?.seo
+            })}
+            loading={isLoading}
+            disabled={!isReadyForDuplicate}
+            style={{ 
+              backgroundColor: isReadyForDuplicate ? "#0045d8" : "#d5e3ff", 
+              boxShadow: "unset", 
+              marginRight: "10px" 
+            }}
+          />
+        </Inline>
       </Box>
     </Flex>
   )

--- a/studio/components/actions/DialogFooter.tsx
+++ b/studio/components/actions/DialogFooter.tsx
@@ -11,7 +11,7 @@ export default function DialogFooter({ page, title, sections, dialogFn, values }
   const pageTitle = values?.title || title;
   const pageSections = values?.sections || sections;
   const setDialogOpen = values?.dialogFn || dialogFn;
-  const isReadyForDuplicate = pageSections?.filter((section) => section.include)?.length !== 0 && pageSections?.filter((section) => !section?.ready)?.length === 0
+  const isReadyForDuplicate = pageSections?.filter((section) => section.include)?.length !== 0
 
   // DUPLICATE DOCUMENT
   const handleDuplicateBtn = async (payload: any) => {
@@ -84,7 +84,7 @@ export default function DialogFooter({ page, title, sections, dialogFn, values }
       });
     }
   }
-
+  
   return (
     <Flex justify="space-between">
       <p className="ml-4 text-sm text-gray-500">

--- a/studio/components/actions/DialogFooter.tsx
+++ b/studio/components/actions/DialogFooter.tsx
@@ -85,11 +85,6 @@ export default function DialogFooter({ page, title, sections, dialogFn, values }
     }
   }
 
-  console.log({
-    title: pageTitle,
-    sections: pageSections
-  })
-
   return (
     <Flex justify="space-between">
       <p className="ml-4 text-sm text-gray-500">

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -31,7 +31,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
           return {
             ...section,
             current: !section.current,
-            ready: !section.current
+            label: `Copy of ${section?.label}`
           }
         } else if(feature === "current") {
           // then just return the existing data
@@ -117,18 +117,15 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
         <Text size={1} weight="bold">
           Title
         </Text>
-    
+        <Text size={1} style={{ marginTop: "3px", marginBottom: "5px" }} muted>
+          A new unique title will help you remember what this page is for later.
+        </Text>
         <div className="relative">
           <TextInput
             fontSize={2}
             value={pageTitle}
             padding={[3, 3, 4]}
             placeholder={page?.title || page?.name}
-            style={{
-              border: "1px solid #fb914e",
-              borderRadius: "5px",
-              outline: "3px solid #ffffff"
-            }}
             onChange={(event) => {
               setPageTitle(event.target.value)
               setValues((prev) => ({...prev, title: event.target.value}))
@@ -146,9 +143,6 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
             </ButtonWithTooltip>
           )}
         </div>
-        <Text size={1} style={{ marginTop: "3px", marginBottom: "5px", color: "#fb914e" }}>
-          Add a unique title to make duplicate stand out from this page
-        </Text>
       </Stack>
       <Box paddingY={4}>
         <Stack space={2}>
@@ -227,11 +221,10 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                             <Inline space={2}>
                               <TextInput
                                 fontSize={2} 
-                                placeholder={page?.sections?.[index]?.label}
+                                placeholder={`Copy of ${page?.sections?.[index]?.label}`}
                                 onChange={(event) => handleUpdateSectionLabel(event, index)}
                                 radius={2}
                                 size={25}
-                                required 
                               />
                               {!section?.include && (
                                 <Badge mode="outline" tone="critical">Not included</Badge> 

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -29,21 +29,17 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
 
   // FEATURE BUTTONS: NEW | EXCLUDE | REVERT REFERENCES
   const handleFeatureButtons = (feature: "current" | "new" | "exclude" | "revert", position: number) => {
+    setFocusIndex(position);
+
     const updated = duplicateSections?.map((section, index) => {
       if(index !== position) {
         return section; // no change
       } else {
         if(feature === "new") {  
-          setFocusIndex(position);
-           
           return {
             ...section,
             current: !section.current,
-            label: `Copy of ${section?.label}`
           }
-        } else if(feature === "current") {
-          // then just return the existing data
-          return page?.sections[position]
         } else if(feature === "exclude") {
           return {
             ...section,
@@ -100,7 +96,6 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
   // UPDATE SECTION LABEL FOR NEW COPY
   const handleUpdateSectionLabel = (event, position: number) => {
     const value = event?.target?.value;
-    const hasValue = value?.trim()?.length !== 0;
 
     const updated = duplicateSections?.map((section, index) => {
       if(index !== position) {
@@ -109,8 +104,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
         // return new shape
         return { 
           ...section,
-          label: value,
-          ready: hasValue
+          label: value
         };
       }
     });
@@ -229,7 +223,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                             <Inline space={2}>
                               <TextInput
                                 fontSize={2} 
-                                placeholder={`Copy of ${page?.sections?.[index]?.label}`}
+                                placeholder={`Copy of ${section?.label}`}
                                 onChange={(event) => handleUpdateSectionLabel(event, index)}
                                 radius={2}
                                 size={25}
@@ -285,7 +279,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                               value={section?._type}
                               disabled={!section?.include}
                               checked={!duplicateSections[index]?.current}
-                              onChange={() => handleFeatureButtons(!duplicateSections[index]?.current ? "current" : "new", index)}
+                              onChange={() => handleFeatureButtons("new", index)}
                             />
                           </ButtonWithTooltip>
                         </Box>

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -14,7 +14,7 @@ import { ComposeIcon, ArrowLeftIcon, RestoreIcon, CloseCircleIcon } from "@sanit
 import { ButtonWithTooltip, SearchBar } from ".";
 
 
-export default function DuplicatePageSettings({ page, variants, values, setValues, setDialogOpen }) {
+export default function DuplicatePageSettings({ page, variants, setValues, setDialogOpen }) {
   let variantStr = "", sectionVariant = "Variant not selected";
 
   const [duplicateSections, setDuplicateSections] = React.useState(page?.sections);
@@ -22,7 +22,7 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
 
 
   // FEATURE BUTTONS: NEW | EXCLUDE | REVERT REFERENCES
-  const handleFeatureButtons = (feature: "new" | "exclude" | "revert", position: number) => {
+  const handleFeatureButtons = (feature: "current" | "new" | "exclude" | "revert", position: number) => {
     const updated = duplicateSections?.map((section, index) => {
       if(index !== position) {
         return section; // no change
@@ -31,8 +31,11 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
           return {
             ...section,
             current: !section.current,
-            ready: !section.ready
+            ready: !section.current
           }
+        } else if(feature === "current") {
+          // then just return the existing data
+          return page?.sections[position]
         } else if(feature === "exclude") {
           return {
             ...section,
@@ -91,16 +94,21 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
     const value = event?.target?.value;
     const hasValue = value?.trim()?.length !== 0;
 
-    setValues((prev) => ({...prev, sections: prev?.sections?.map((section, prevIndex) => {
-      if (prevIndex === position) {
-        return {
-          ...section, 
-          label: hasValue ? value : page?.sections?.[position]?.label,
-          ready: hasValue ? true : false
-        }
+    const updated = duplicateSections?.map((section, index) => {
+      if(index !== position) {
+        return section; // no change
+      } else {
+        // return new shape
+        return { 
+          ...section,
+          label: value,
+          ready: hasValue
+        };
       }
-      return section
-    })}))
+    });
+
+    setDuplicateSections(updated);
+    setValues((prev) => ({...prev, sections: updated, dialogFn: setDialogOpen}));
   }
 
   return (
@@ -273,7 +281,7 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
                               value={section?._type}
                               disabled={!section?.include}
                               checked={!duplicateSections[index]?.current}
-                              onChange={() => handleFeatureButtons("new", index)}
+                              onChange={() => handleFeatureButtons(!duplicateSections[index]?.current ? "current" : "new", index)}
                             />
                           </ButtonWithTooltip>
                         </Box>

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -11,7 +11,7 @@ import {
   TextInput,
   Tooltip, 
 } from "@sanity/ui";
-import { ComposeIcon, ArrowLeftIcon, RestoreIcon, CloseCircleIcon, InfoOutlineIcon, CheckmarkIcon } from "@sanity/icons"
+import { ComposeIcon, ArrowLeftIcon, RestoreIcon, CloseCircleIcon, InfoOutlineIcon, CheckmarkCircleIcon } from "@sanity/icons"
 import { ButtonWithTooltip, SearchBar } from ".";
 
 
@@ -38,6 +38,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
           return {
             ...section,
             include: !section?.include,
+            current: true,
             isEditing: false,
           }
         } else if(feature === "revert") {
@@ -125,6 +126,10 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
             value={pageTitle}
             padding={[3, 3, 4]}
             placeholder={page?.title || page?.name}
+            style={{
+              border: "1px solid #fb914e",
+              borderRadius: "5px",
+            }}
             onChange={(event) => {
               setPageTitle(event.target.value)
               setValues((prev) => ({...prev, title: event.target.value}))
@@ -166,7 +171,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                 <Card 
                   padding={3} 
                   radius={2} 
-                  shadow={1} 
+                  shadow={1}
                   style={{
                     backgroundColor: !section?.include && "#e5e7ebb5"
                   }}
@@ -227,7 +232,8 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                                 placeholder={page?.sections?.[index]?.label}
                                 onChange={(event) => handleInputSectionLabel(event?.target?.value, index)}
                                 radius={2}
-                                iconRight={(sectionLabel?.trim()?.length > 0 && sectionLabel !== section?.label) && CheckmarkIcon}
+                                iconRight={(sectionLabel?.trim()?.length > 0 && sectionLabel !== section?.label) ? <CheckmarkCircleIcon style={{ color: "#fb914e" }} /> : <InfoOutlineIcon/>}
+                                size={25}
                                 required 
                               />
                               {!section?.include && (

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -239,6 +239,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                                 onChange={(event) => handleUpdateSectionLabel(event, index)}
                                 radius={2}
                                 size={30}
+                                autoFocus
                               />
                               {!section?.include && (
                                 <Badge mode="outline" tone="critical">Not included</Badge> 

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -127,6 +127,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
             style={{
               border: "1px solid #fb914e",
               borderRadius: "5px",
+              outline: "3px solid #ffffff"
             }}
             onChange={(event) => {
               setPageTitle(event.target.value)

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -19,6 +19,13 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
 
   const [duplicateSections, setDuplicateSections] = React.useState(page?.sections);
   const [pageTitle, setPageTitle] = React.useState("");
+  const focusInput = React.useRef([]);
+  const [focusIndex, setFocusIndex] = React.useState(-1);
+
+  // effect does DOM focus on input element when the focusIndex is updated
+  React.useEffect(() => {
+    focusInput.current[focusIndex]?.focus();
+  }, [focusIndex]);
 
   // FEATURE BUTTONS: NEW | EXCLUDE | REVERT REFERENCES
   const handleFeatureButtons = (feature: "current" | "new" | "exclude" | "revert", position: number) => {
@@ -26,7 +33,9 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
       if(index !== position) {
         return section; // no change
       } else {
-        if(feature === "new") {          
+        if(feature === "new") {  
+          setFocusIndex(position);
+           
           return {
             ...section,
             current: !section.current,
@@ -224,6 +233,8 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                                 onChange={(event) => handleUpdateSectionLabel(event, index)}
                                 radius={2}
                                 size={25}
+                                onBlur={() => setFocusIndex(null)} // ensure focus index is set to no value when focus is lost
+                                ref={(ref) => focusInput.current[index] = ref}
                               />
                               {!section?.include && (
                                 <Badge mode="outline" tone="critical">Not included</Badge> 

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -18,26 +18,16 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
   let variantStr = "", sectionVariant = "Variant not selected";
 
   const [duplicateSections, setDuplicateSections] = React.useState(page?.sections);
-  const [prevState, setPrevState] = React.useState(duplicateSections); // placeholder used when section label is updated 
   const [pageTitle, setPageTitle] = React.useState("");
-  const focusInput = React.useRef([]);
-  const [focusIndex, setFocusIndex] = React.useState(-1);
-
-  // effect does DOM focus on input element when the focusIndex is updated
-  React.useEffect(() => {
-    focusInput.current[focusIndex]?.focus();
-  }, [focusIndex]);
 
   // FEATURE BUTTONS: NEW | EXCLUDE | REVERT REFERENCES
   const handleFeatureButtons = (type: "new" | "exclude" | "revert", position: number) => {
-    setFocusIndex(position);
-
     const updated = duplicateSections?.map((section, index) => {
       if(index !== position) {
         return section; // no change
       } else {
         if(type === "new") {  
-          if(section?.current) { 
+          if(section?.current) {             
             // create new copy of section
             return {
               ...section,
@@ -47,7 +37,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
           } else {
             // use current section
             return {
-              ...prevState[position],
+              ...section,
               label: section?.label?.replace("Copy of ", ""),
               current: true,
               include: true,
@@ -57,6 +47,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
         } else if(type === "exclude") {
           return {
             ...section,
+            label: !section?.customLabel ? section?.label?.replace("Copy of ", "") : section?.customLabel,
             include: !section?.include,
             current: true,
             isEditing: false,
@@ -103,7 +94,6 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
       }
     });
 
-    setPrevState(duplicateSections);
     setDuplicateSections(updated);
     setValues((prev) => ({...prev, sections: updated, dialogFn: setDialogOpen}));
   }
@@ -120,12 +110,12 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
         // return new shape
         return { 
           ...section,
-          label: hasValue ? value : section?.label
+          customLabel: hasValue ? value : ""
         };
       }
     });
 
-    setPrevState(duplicateSections);
+    setDuplicateSections(updated);
     setValues((prev) => ({...prev, sections: updated, dialogFn: setDialogOpen}));
   }
 
@@ -240,15 +230,15 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                       <Flex justify="space-between">
                         <Inline className="showBtn" space={2} padding={2}>
                           {!section?.current ? (
-                            <Inline space={2}>
+                            <Inline space={2} style={{ paddingBottom: 3, minHeight: "24px" }}>
                               <TextInput
                                 fontSize={2} 
+                                padding={2}
+                                value={!section?.current && section?.customLabel ? section?.customLabel : ""}
                                 placeholder={section?.label}
                                 onChange={(event) => handleUpdateSectionLabel(event, index)}
                                 radius={2}
-                                size={25}
-                                onBlur={() => setFocusIndex(null)} // ensure focus index is set to no value when focus is lost
-                                ref={(ref) => focusInput.current[index] = ref}
+                                size={30}
                               />
                               {!section?.include && (
                                 <Badge mode="outline" tone="critical">Not included</Badge> 
@@ -259,7 +249,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
                             </Inline>
                           ) : (
                             <Inline space={2}>
-                              <Text style={{ paddingTop: 7, minHeight: "24px" }}>
+                              <Text style={{ paddingTop: 8, minHeight: "24px" }}>
                                 {section?.label ?? "Untitled document"}
                               </Text>
                               {!section?.include && (

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -28,7 +28,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
   }, [focusIndex]);
 
   // FEATURE BUTTONS: NEW | EXCLUDE | REVERT REFERENCES
-  const handleFeatureButtons = (feature: "current" | "new" | "exclude" | "revert", position: number) => {
+  const handleFeatureButtons = (feature: "new" | "exclude" | "revert", position: number) => {
     setFocusIndex(position);
 
     const updated = duplicateSections?.map((section, index) => {

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -20,7 +20,6 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
   const [duplicateSections, setDuplicateSections] = React.useState(page?.sections);
   const [pageTitle, setPageTitle] = React.useState("");
 
-
   // FEATURE BUTTONS: NEW | EXCLUDE | REVERT REFERENCES
   const handleFeatureButtons = (feature: "current" | "new" | "exclude" | "revert", position: number) => {
     const updated = duplicateSections?.map((section, index) => {
@@ -125,7 +124,7 @@ export default function DuplicatePageSettings({ page, variants, setValues, setDi
             fontSize={2}
             value={pageTitle}
             padding={[3, 3, 4]}
-            placeholder={page?.title || page?.name}
+            placeholder={`Copy of ${page?.title || page?.name}`}
             onChange={(event) => {
               setPageTitle(event.target.value)
               setValues((prev) => ({...prev, title: event.target.value}))

--- a/studio/components/actions/DuplicatePageSettings.tsx
+++ b/studio/components/actions/DuplicatePageSettings.tsx
@@ -10,7 +10,7 @@ import {
   Text, 
   TextInput,
 } from "@sanity/ui";
-import { ComposeIcon, ArrowLeftIcon, RestoreIcon, CloseCircleIcon, InfoOutlineIcon, CheckmarkCircleIcon } from "@sanity/icons"
+import { ComposeIcon, ArrowLeftIcon, RestoreIcon, CloseCircleIcon } from "@sanity/icons"
 import { ButtonWithTooltip, SearchBar } from ".";
 
 
@@ -27,11 +27,11 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
       if(index !== position) {
         return section; // no change
       } else {
-        if(feature === "new") {
+        if(feature === "new") {          
           return {
             ...section,
             current: !section.current,
-            ready: !section?.ready,
+            ready: !section.ready
           }
         } else if(feature === "exclude") {
           return {
@@ -88,10 +88,10 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
 
   // UPDATE SECTION LABEL FOR NEW COPY
   const handleUpdateSectionLabel = (event, position: number) => {
-    setValues((prev) => ({...prev, sections: prev?.sections?.map((section, prevIndex) => {
-      const value = event?.target?.value;
-      const hasValue = value?.trim()?.length !== 0;
+    const value = event?.target?.value;
+    const hasValue = value?.trim()?.length !== 0;
 
+    setValues((prev) => ({...prev, sections: prev?.sections?.map((section, prevIndex) => {
       if (prevIndex === position) {
         return {
           ...section, 
@@ -99,7 +99,6 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
           ready: hasValue ? true : false
         }
       }
-
       return section
     })}))
   }
@@ -231,9 +230,6 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
                               {!section?.current && (
                                 <Badge mode="outline" tone="primary">New</Badge>
                               )}
-                              {section?.replaced && (
-                                <Badge mode="outline" tone="caution">Updated</Badge>
-                              )}
                             </Inline>
                           ) : (
                             <Inline space={2}>
@@ -242,9 +238,6 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
                               </Text>
                               {!section?.include && (
                                 <Badge mode="outline" tone="critical">Not included</Badge> 
-                              )}
-                              {section?.replaced && (
-                                <Badge mode="outline" tone="caution">Updated</Badge>
                               )}
                             </Inline>
                           )}
@@ -290,6 +283,13 @@ export default function DuplicatePageSettings({ page, variants, values, setValue
                           {`${sectionVariant} • ${section?._type?.toUpperCase()}`}
                         </Text>
                       </Box>
+                      {section?.replaced && (
+                        <Box padding={2}>
+                          <Text size={1} style={{ fontStyle: "italic", color: "blue" }} muted>
+                            This section has been updated
+                          </Text>
+                        </Box>
+                      )}
                     </>
                   )}
                 </Card>

--- a/studio/components/actions/SearchBar.tsx
+++ b/studio/components/actions/SearchBar.tsx
@@ -11,7 +11,7 @@ export default function SearchBar({ searchItems, onClickHandler }: SearchItemsTy
       openButton
       fontSize={2}
       padding={3}
-      icon={MdManageSearch}
+      //icon={MdManageSearch}
       id="variants-list-searchbar"
       options={options}
       placeholder="Select to replace current one"

--- a/studio/documentActions/actions/CustomDuplicateAction.tsx
+++ b/studio/documentActions/actions/CustomDuplicateAction.tsx
@@ -71,6 +71,7 @@ export default function CustomDuplicateAction(props) {
         <DuplicatePageSettings {...{ 
             page, 
             variants, 
+            values,
             setValues, 
             setDialogOpen 
           }} 

--- a/studio/documentActions/actions/CustomDuplicateAction.tsx
+++ b/studio/documentActions/actions/CustomDuplicateAction.tsx
@@ -32,7 +32,6 @@ export default function CustomDuplicateAction(props) {
               "include": true,
               "replaced": false,
               "isEditing": false,
-              "ready": true,
             }, 
           }`, 
           { documentId: documentId }
@@ -50,7 +49,6 @@ export default function CustomDuplicateAction(props) {
                   "include": true,
                   "replaced": false,
                   "isEditing": false,
-                  "ready": true,
                 }`,
                 { sections: result?.sections?.map((section) => section?._type) }
             )

--- a/studio/documentActions/actions/CustomDuplicateAction.tsx
+++ b/studio/documentActions/actions/CustomDuplicateAction.tsx
@@ -9,6 +9,7 @@ export default function CustomDuplicateAction(props) {
 
   const [page, setPage] = React.useState(null);
   const [variants, setVariants] = React.useState(null);
+  const [allPages, setAllPages] = React.useState(null);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [values, setValues] = React.useState({
     page: document,
@@ -56,6 +57,17 @@ export default function CustomDuplicateAction(props) {
           }
         });
 
+      // fetch all documents in current project with the `slug` field
+      await sanityClient
+        .fetch(`*[defined(slug)] {
+            title,
+            slug,
+            _id,
+            _type
+          }`
+        )
+        .then((result) => setAllPages(result));
+
       setDialogOpen(true);
     },
     dialog: dialogOpen && {
@@ -80,7 +92,8 @@ export default function CustomDuplicateAction(props) {
             sections: page?.sections, 
             dialogFn: setDialogOpen,
             values,
-            setValues 
+            setValues,
+            allPages 
           }} 
         />
       )

--- a/studio/documentActions/actions/CustomDuplicateAction.tsx
+++ b/studio/documentActions/actions/CustomDuplicateAction.tsx
@@ -9,7 +9,6 @@ export default function CustomDuplicateAction(props) {
 
   const [page, setPage] = React.useState(null);
   const [variants, setVariants] = React.useState(null);
-  const [allPages, setAllPages] = React.useState(null);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [values, setValues] = React.useState({
     page: document,
@@ -57,17 +56,6 @@ export default function CustomDuplicateAction(props) {
           }
         });
 
-      // fetch all documents in current project with the `slug` field
-      await sanityClient
-        .fetch(`*[defined(slug)] {
-            title,
-            slug,
-            _id,
-            _type
-          }`
-        )
-        .then((result) => setAllPages(result));
-
       setDialogOpen(true);
     },
     dialog: dialogOpen && {
@@ -93,7 +81,6 @@ export default function CustomDuplicateAction(props) {
             dialogFn: setDialogOpen,
             values,
             setValues,
-            allPages 
           }} 
         />
       )

--- a/studio/documentActions/actions/CustomDuplicateAction.tsx
+++ b/studio/documentActions/actions/CustomDuplicateAction.tsx
@@ -14,7 +14,6 @@ export default function CustomDuplicateAction(props) {
     page: document,
     title: document?.title || document?.name,
     sections: document?.sections,
-    ready: false,
   })
 
   return {

--- a/studio/documentActions/actions/CustomDuplicateAction.tsx
+++ b/studio/documentActions/actions/CustomDuplicateAction.tsx
@@ -70,7 +70,6 @@ export default function CustomDuplicateAction(props) {
         <DuplicatePageSettings {...{ 
             page, 
             variants, 
-            values,
             setValues, 
             setDialogOpen 
           }} 

--- a/studio/documentActions/actions/CustomDuplicateAction.tsx
+++ b/studio/documentActions/actions/CustomDuplicateAction.tsx
@@ -14,6 +14,7 @@ export default function CustomDuplicateAction(props) {
     page: document,
     title: document?.title || document?.name,
     sections: document?.sections,
+    ready: false,
   })
 
   return {
@@ -31,7 +32,8 @@ export default function CustomDuplicateAction(props) {
               "current": true,
               "include": true,
               "replaced": false,
-              "isEditing": false, 
+              "isEditing": false,
+              "ready": true,
             }, 
           }`, 
           { documentId: documentId }
@@ -49,6 +51,7 @@ export default function CustomDuplicateAction(props) {
                   "include": true,
                   "replaced": false,
                   "isEditing": false,
+                  "ready": true,
                 }`,
                 { sections: result?.sections?.map((section) => section?._type) }
             )
@@ -60,10 +63,10 @@ export default function CustomDuplicateAction(props) {
     },
     dialog: dialogOpen && {
       type: "dialog",
-      onClose: () => {
-        setDialogOpen(false);
-      },
-      header: "Duplicate document content",
+      // onClose: () => {
+      //   setDialogOpen(false);
+      // }, // comment to prevent dialog from closing on click outside
+      header: "Duplicate page content",
       content: (
         <DuplicatePageSettings {...{ 
             page, 

--- a/studio/documentActions/actions/CustomDuplicateAction.tsx
+++ b/studio/documentActions/actions/CustomDuplicateAction.tsx
@@ -18,7 +18,7 @@ export default function CustomDuplicateAction(props) {
 
   return {
     icon: CopyIcon,
-    tone: "primary",
+    tone: "critical",
     label: "Duplicate",
     onHandle: async () => {
       // fetch all ADDED sections for the current document
@@ -79,7 +79,8 @@ export default function CustomDuplicateAction(props) {
             title: page?.title, 
             sections: page?.sections, 
             dialogFn: setDialogOpen,
-            values 
+            values,
+            setValues 
           }} 
         />
       )


### PR DESCRIPTION
1. Section label
    - [x]    If toggle is TRUE, update label to text input
    - [x]    If toggle is FALSE, revert back to display label
    - [x]    Text input value default placeholder and value **_Copy of [original section label]_** if left blank
    - [x]    Add text input focus when toggle button is enabled
    - [x]     Retain input custom label when toggle is TRUE/FALSE or on EDIT

2. Title
     - [x] Placeholder and default title value should be **_Copy of [original page title]_**
     - [x] By default the input field should be empty so if value is not added, then use the original page title
     - [x] Add helper text for the input field to encourage updating page title
     - [x] If added page title already exists in current studio, append a random string to the slug to make it unique and avoid 
              validation warnings

3. Disable auto close modal on outside click (added a `Cancel` button for closing the modal)
4. The `Duplicate` button should always be enabled except when all sections are **excluded**
5. Show popover confirmation dialog on `Cancel` if any edits where made on the dialog