### PR TITLE
Fixes for errors when migrating webriq site to 3.2.2

### DIFF
--- a/components/InlineEditor.tsx
+++ b/components/InlineEditor.tsx
@@ -119,7 +119,7 @@ export default function InlineEditor({
                       document?.type === "mainProduct"
                         ? "product-fieldgroup-tabs product-fieldgroup-select"
                         : "fieldgroup-tabs fieldgroup-select"
-                    }`}
+                    } h-full`}
                   >
                     <StudioLayout />
                   </div>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@sanity/icons": "^2.3.1",
     "@sanity/image-url": "^1.0.2",
     "@sanity/types": "^3.11.3",
-    "@sanity/ui": "^1.3.2",
+    "@sanity/ui": "^1.7.3",
     "@sanity/vision": "^3.11.3",
     "@stripe/react-stripe-js": "^2.1.0",
     "@stripe/stripe-js": "^1.52.1",


### PR DESCRIPTION
SUMMARY:

Updates `@sanity/ui` packages to `1.7.3` to fix the Component plugin buggy UI.

![image](https://github.com/webriq-pagebuilder/site-template-default/assets/96686444/952738b6-8406-4f4b-b1b9-793d4c5200f0)

Added `h-full` classname to inline editor component to fix the height issue.

![image](https://github.com/webriq-pagebuilder/site-template-default/assets/96686444/d9103e43-2955-4f49-b897-42d45970aadc)
