### PR TITLE
Fix SEO Meta tags not updating on page navigation

### DIFF
--- a/components/list.tsx
+++ b/components/list.tsx
@@ -68,6 +68,3 @@ export function filterDataToSingleItem(data, preview) {
 
   return data[0];
 }
-
-// SEO component to add required metatags to pages (add component inside <Head></Head>)
-export const SEO = dynamic(() => import("components/SEO"));

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -10,11 +10,12 @@ import { PageSections } from "components/page";
 import BlogSections from "components/blog";
 import { PreviewBanner } from "components/PreviewBanner";
 import { PreviewNoContent } from "components/PreviewNoContent";
-import { filterDataToSingleItem, SEO } from "components/list";
+import { filterDataToSingleItem } from "components/list";
+import { SEO } from "components/SEO";
 import PageNotFound from "pages/404";
 import InlineEditorContextProvider from "context/InlineEditorContext";
 import { GetStaticPaths, GetStaticProps } from "next";
-import { CommonPageData, BlogsData, DefaultSeoData } from "types";
+import { CommonPageData, BlogsData, SeoTags } from "types";
 import { addSEOJsonLd } from "components/SEO";
 
 interface PageBySlugProps {
@@ -22,7 +23,8 @@ interface PageBySlugProps {
   preview: boolean;
   token: string | null;
   source: string;
-  defaultSeo: DefaultSeoData;
+  seo?: SeoTags[];
+  seoSchema?: any;
 }
 
 interface DocumentWithPreviewProps {
@@ -30,7 +32,6 @@ interface DocumentWithPreviewProps {
   slug: string | string[];
   token: string | null;
   source: string;
-  defaultSeo: DefaultSeoData;
 }
 
 interface Data {
@@ -44,13 +45,7 @@ export interface PageData extends CommonPageData {
   title: string;
 }
 
-export function PageBySlug({
-  data,
-  preview,
-  token,
-  source,
-  defaultSeo,
-}: PageBySlugProps) {
+export function PageBySlug({ data, preview, token, source }: PageBySlugProps) {
   const router = useRouter();
   const slug = router.query.slug;
   const showInlineEditor = source === "studio";
@@ -65,7 +60,12 @@ export function PageBySlug({
           <PreviewSuspense fallback="Loading...">
             <InlineEditorContextProvider showInlineEditor={showInlineEditor}>
               <DocumentWithPreview
-                {...{ data, token: token || null, slug, source, defaultSeo }}
+                {...{
+                  data,
+                  token: token || null,
+                  slug,
+                  source,
+                }}
               />
             </InlineEditorContextProvider>
           </PreviewSuspense>
@@ -73,7 +73,7 @@ export function PageBySlug({
       );
     }
 
-    return <Document {...{ data, defaultSeo }} />;
+    return <Document {...{ data }} />;
   }
 }
 
@@ -83,13 +83,7 @@ export function PageBySlug({
  *
  * @returns Document with published data
  */
-function Document({
-  data,
-  defaultSeo,
-}: {
-  data: Data;
-  defaultSeo: DefaultSeoData;
-}) {
+function Document({ data }: { data: Data }) {
   const publishedData = data?.pageData || data?.blogData; // latest published data in Sanity
 
   // General safeguard against empty data
@@ -97,35 +91,8 @@ function Document({
     return null;
   }
 
-  const { title, _type, seo } = publishedData;
-
   return (
     <>
-      <Head>
-        <SEO
-          data={{
-            pageTitle: title,
-            type: _type,
-            route: publishedData?.slug,
-            ...seo,
-          }}
-          defaultSeo={defaultSeo}
-        />
-        {/* Structured data (JSON-LD encoding) */}
-        <script
-          key={`${_type}-jsonld`}
-          type="application/ld+json"
-          dangerouslySetInnerHTML={addSEOJsonLd({
-            seo: seo,
-            type: _type,
-            slug: publishedData?.slug,
-            defaults: defaultSeo,
-            pageData: publishedData,
-          })}
-        />
-        <title>{seo?.seoTitle ?? title ?? "WebriQ Studio"}</title>
-      </Head>
-
       {/*  Show page sections */}
       {data?.pageData && <PageSections data={data?.pageData} />}
 
@@ -148,7 +115,6 @@ function DocumentWithPreview({
   data,
   slug,
   token = null,
-  defaultSeo,
 }: DocumentWithPreviewProps) {
   // Current drafts data in Sanity
   const previewDataEventSource = usePreview(
@@ -167,35 +133,10 @@ function DocumentWithPreview({
     return null;
   }
 
-  const { title, seo, _type } = previewData;
+  const { _type } = previewData;
 
   return (
     <>
-      <Head>
-        <SEO
-          data={{
-            pageTitle: title,
-            type: _type,
-            route: previewData?.slug,
-            ...seo,
-          }}
-          defaultSeo={defaultSeo}
-        />
-        {/* Structured data (JSON-LD encoding) */}
-        <script
-          key={`${_type}-jsonld`}
-          type="application/ld+json"
-          dangerouslySetInnerHTML={addSEOJsonLd({
-            seo: seo,
-            type: _type,
-            slug: previewData?.slug,
-            defaults: defaultSeo,
-            pageData: previewData,
-          })}
-        />
-        <title>{seo?.seoTitle ?? title ?? "WebriQ Studio"}</title>
-      </Head>
-
       {/* if page has no sections, show no sections only in preview */}
       {_type === "page" &&
         "sections" in previewData &&
@@ -232,16 +173,43 @@ export const getStaticProps: GetStaticProps = async ({
   const singlePageData: PageData = filterDataToSingleItem(page, preview);
   const singleBlogData: BlogsData = filterDataToSingleItem(blogData, preview);
 
+  const data = {
+    pageData: singlePageData || null,
+    blogData: singleBlogData || null,
+  };
+
+  // SEO tags
+  const seo = SEO({
+    data: {
+      title:
+        data?.pageData?.title || data?.blogData?.title || "Stackshift page",
+      type: data?.pageData?._type || data?.blogData?._type || "",
+      route: params?.slug,
+      ...(data?.pageData?.seo || data?.blogData?.seo),
+    },
+    defaultSeo: globalSEO,
+  });
+
+  // Structured data (JSON-LD encoding)
+  const seoSchema = {
+    key: `${data?.pageData?._type || data?.blogData?._type}-jsonld`,
+    innerHTML: addSEOJsonLd({
+      seo: seo,
+      type: data?.pageData?._type || data?.blogData?._type,
+      defaults: globalSEO,
+      slug: params?.slug,
+      pageData: data?.pageData || data?.blogData,
+    }),
+  };
+
   return {
     props: {
       preview,
       token: (preview && previewData.token) || "",
       source: (preview && previewData?.source) || "",
-      data: {
-        pageData: singlePageData || null,
-        blogData: singleBlogData || null,
-      },
-      defaultSeo: globalSEO,
+      data,
+      seo,
+      seoSchema,
     },
     // If webhooks isn't setup then attempt to re-generate in 1 minute intervals
     revalidate: process.env.SANITY_REVALIDATE_SECRET ? undefined : 60,

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -15,7 +15,7 @@ import { SEO } from "components/SEO";
 import PageNotFound from "pages/404";
 import InlineEditorContextProvider from "context/InlineEditorContext";
 import { GetStaticPaths, GetStaticProps } from "next";
-import { CommonPageData, BlogsData, SeoTags } from "types";
+import { CommonPageData, BlogsData, SeoTags, SeoSchema } from "types";
 import { addSEOJsonLd } from "components/SEO";
 
 interface PageBySlugProps {
@@ -24,7 +24,7 @@ interface PageBySlugProps {
   token: string | null;
   source: string;
   seo?: SeoTags[];
-  seoSchema?: any;
+  seoSchema?: SeoSchema;
 }
 
 interface DocumentWithPreviewProps {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,13 @@
 import type { AppProps } from "next/app";
+import Head from "next/head";
 import "../styles/globals.css";
 // import React, { useEffect } from "react";
 // import useScript from "utils/useScript";
 // import { useRouter } from "next/router";
 
 function App({ Component, pageProps }: AppProps) {
+  const { seo = [], seoSchema = {} } = pageProps;
+
   // let script_status = useScript(process.env.NEXT_PUBLIC_ECWID_SCRIPT);
   // const { preview } = pageProps;
   // const router = useRouter();
@@ -47,7 +50,29 @@ function App({ Component, pageProps }: AppProps) {
   //   }
   // }, [script_status]);
 
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Head>
+        {seo?.map((tags) => {
+          if (tags?.key === "page-title") {
+            return <title key={tags?.key}>{tags?.title}</title>;
+          } else if (tags?.href) {
+            return <link {...tags} key={tags?.key} />;
+          } else if (tags) {
+            return <meta {...tags} key={tags?.key} />;
+          }
+        })}
+        {seoSchema && (
+          <script
+            key={seoSchema?.key}
+            type="application/ld+json"
+            dangerouslySetInnerHTML={seoSchema?.innerHTML}
+          />
+        )}
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 }
 
 export default App;

--- a/pages/collections/[slug].tsx
+++ b/pages/collections/[slug].tsx
@@ -1,7 +1,6 @@
 /** This component displays content for the COLLECTIONS page */
 
 import React, { useEffect } from "react";
-import Head from "next/head";
 import { useRouter } from "next/router";
 import { groq } from "next-sanity";
 import { PreviewSuspense } from "next-sanity/preview";
@@ -9,7 +8,8 @@ import { sanityClient, getClient } from "lib/sanity.client";
 import { usePreview } from "lib/sanity.preview";
 import { collectionsQuery, globalSEOQuery } from "pages/api/query";
 import PageNotFound from "pages/404";
-import { filterDataToSingleItem, SEO } from "components/list";
+import { filterDataToSingleItem } from "components/list";
+import { SEO } from "components/SEO";
 import { PreviewBanner } from "components/PreviewBanner";
 import { PreviewNoContent } from "components/PreviewNoContent";
 import { CollectionSections } from "components/page/store/collections";
@@ -19,7 +19,7 @@ import {
   CommonPageData,
   CommonSections,
   CollectionProduct,
-  DefaultSeoData,
+  SeoTags,
 } from "types";
 
 interface CollectionPageBySlugProps {
@@ -27,7 +27,7 @@ interface CollectionPageBySlugProps {
   preview: boolean;
   token: string;
   source: string;
-  defaultSeo: DefaultSeoData;
+  seo?: SeoTags[];
 }
 interface Data {
   collectionData: CollectionData;
@@ -47,7 +47,6 @@ interface DocumentWithPreviewProps {
   data: Data;
   slug: string | string[];
   token: string;
-  defaultSeo: DefaultSeoData;
 }
 
 function CollectionPageBySlug({
@@ -55,7 +54,6 @@ function CollectionPageBySlug({
   preview,
   token,
   source,
-  defaultSeo,
 }: CollectionPageBySlugProps) {
   const router = useRouter();
   const slug = router.query.slug;
@@ -74,16 +72,14 @@ function CollectionPageBySlug({
           <PreviewBanner />
           <PreviewSuspense fallback="Loading...">
             <InlineEditorContextProvider showInlineEditor={showInlineEditor}>
-              <DocumentWithPreview
-                {...{ data, token: token || null, slug, defaultSeo }}
-              />
+              <DocumentWithPreview {...{ data, token: token || null, slug }} />
             </InlineEditorContextProvider>
           </PreviewSuspense>
         </>
       );
     }
 
-    return <Document {...{ data, defaultSeo }} />;
+    return <Document {...{ data }} />;
   }
 }
 
@@ -93,13 +89,7 @@ function CollectionPageBySlug({
  *
  * @returns Document with published data
  */
-function Document({
-  data,
-  defaultSeo,
-}: {
-  data: Data;
-  defaultSeo: DefaultSeoData;
-}) {
+function Document({ data }: { data: Data }) {
   const publishedData = data?.collectionData; // latest published data in Sanity
 
   // General safeguard against empty data
@@ -107,40 +97,7 @@ function Document({
     return null;
   }
 
-  const {
-    commonSections, // sections from Store > Pages > Collections
-    name, // collection name
-    seo, // collection page SEO
-    _type, // page type
-  } = publishedData;
-
-  const finalSEO = commonSections?.seo ?? seo;
-
-  return (
-    <>
-      <Head>
-        <SEO
-          data={{
-            pageTitle: name,
-            type: _type,
-            route: publishedData?.slug,
-            ...finalSEO,
-          }}
-          defaultSeo={defaultSeo}
-        />
-        <link rel="icon" href="../favicon.ico" />
-        <title>
-          {seo?.seoTitle ??
-            commonSections?.seo?.seoTitle ??
-            name ??
-            "WebriQ Studio"}
-        </title>
-      </Head>
-
-      {/* Show Product page sections */}
-      {data?.collectionData && <CollectionSections data={publishedData} />}
-    </>
-  );
+  return data?.collectionData && <CollectionSections data={publishedData} />;
 }
 
 /**
@@ -156,7 +113,6 @@ function DocumentWithPreview({
   data,
   slug,
   token = null,
-  defaultSeo,
 }: DocumentWithPreviewProps) {
   // Current drafts data in Sanity
   const previewDataEventSource = usePreview(token, collectionsQuery, { slug });
@@ -168,36 +124,8 @@ function DocumentWithPreview({
     return null;
   }
 
-  const {
-    commonSections, // sections from Store > Pages > Collections
-    name, // collection name
-    seo, // collection page SEO
-    _type, // page type
-  } = previewData;
-
-  const finalSEO = commonSections?.seo ?? seo;
-
   return (
     <>
-      <Head>
-        <SEO
-          data={{
-            pageTitle: name,
-            type: _type,
-            route: previewData?.slug,
-            ...finalSEO,
-          }}
-          defaultSeo={defaultSeo}
-        />
-        <link rel="icon" href="../favicon.ico" />
-        <title>
-          {seo?.seoTitle ??
-            commonSections?.seo?.seoTitle ??
-            name ??
-            "WebriQ Studio"}
-        </title>
-      </Head>
-
       {/* if no sections, show no sections only in preview */}
       {(!previewData ||
         !previewData?.sections ||
@@ -232,15 +160,28 @@ export async function getStaticProps({
     preview
   );
 
+  const data = {
+    collectionData: singleCollectionsData || null,
+  };
+
+  // SEO tags
+  const seo = SEO({
+    data: {
+      title: data?.collectionData?.name || "Stackshift | Collections page",
+      type: data?.collectionData?._type || "mainCollection",
+      route: `collections/${params?.slug}`,
+      ...data?.collectionData?.seo,
+    },
+    defaultSeo: globalSEO,
+  });
+
   return {
     props: {
       preview,
       token: (preview && previewData.token) || "",
       source: (preview && previewData.source) || "",
-      data: {
-        collectionData: singleCollectionsData || null,
-      },
-      defaultSeo: globalSEO,
+      data,
+      seo,
     },
     // If webhooks isn't setup then attempt to re-generate in 1 minute intervals
     revalidate: process.env.SANITY_REVALIDATE_SECRET ? undefined : 60,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ import { filterDataToSingleItem } from "components/list";
 import { SEO } from "components/SEO";
 import { PreviewBanner } from "components/PreviewBanner";
 import InlineEditorContextProvider from "context/InlineEditorContext";
-import { CommonPageData, SeoTags } from "types";
+import { CommonPageData, SeoTags, SeoSchema } from "types";
 import { addSEOJsonLd } from "components/SEO";
 
 interface HomeProps {
@@ -18,7 +18,7 @@ interface HomeProps {
   token?: string | null;
   source?: string;
   seo?: SeoTags[];
-  seoSchema?: any;
+  seoSchema?: SeoSchema;
 }
 
 interface DocumentWithPreviewProps {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import Head from "next/head";
 import { PreviewSuspense } from "next-sanity/preview";
 import { getClient } from "lib/sanity.client";
 import { homeQuery, globalSEOQuery } from "./api/query";
 import { usePreview } from "lib/sanity.preview";
 import { PageSections } from "components/page";
 import { PreviewNoContent } from "components/PreviewNoContent";
-import { filterDataToSingleItem, SEO } from "components/list";
+import { filterDataToSingleItem } from "components/list";
+import { SEO } from "components/SEO";
 import { PreviewBanner } from "components/PreviewBanner";
 import InlineEditorContextProvider from "context/InlineEditorContext";
-import { CommonPageData, DefaultSeoData } from "types";
+import { CommonPageData, SeoTags } from "types";
 import { addSEOJsonLd } from "components/SEO";
 
 interface HomeProps {
@@ -17,13 +17,13 @@ interface HomeProps {
   preview: boolean;
   token?: string | null;
   source?: string;
-  defaultSeo: DefaultSeoData;
+  seo?: SeoTags[];
+  seoSchema?: any;
 }
 
 interface DocumentWithPreviewProps {
   data: Data;
   token: string | null;
-  defaultSeo: DefaultSeoData;
 }
 
 interface Data {
@@ -36,7 +36,7 @@ interface PageData extends CommonPageData {
   title: string;
 }
 
-function Home({ data, preview, token, source, defaultSeo }: HomeProps) {
+function Home({ data, preview, token, source }: HomeProps) {
   const showInlineEditor = source === "studio";
 
   if (preview) {
@@ -45,14 +45,14 @@ function Home({ data, preview, token, source, defaultSeo }: HomeProps) {
         <PreviewBanner />
         <PreviewSuspense fallback="Loading...">
           <InlineEditorContextProvider showInlineEditor={showInlineEditor}>
-            <DocumentWithPreview {...{ data, token, defaultSeo }} />
+            <DocumentWithPreview {...{ data, token }} />
           </InlineEditorContextProvider>
         </PreviewSuspense>
       </>
     );
   }
 
-  return <Document {...{ data, defaultSeo }} />;
+  return <Document {...{ data }} />;
 }
 
 /**
@@ -61,13 +61,7 @@ function Home({ data, preview, token, source, defaultSeo }: HomeProps) {
  *
  * @returns Document with published data
  */
-function Document({
-  data,
-  defaultSeo,
-}: {
-  data: Data;
-  defaultSeo: DefaultSeoData;
-}) {
+function Document({ data }: { data: Data }) {
   const publishedData = data?.pageData;
 
   // General safeguard against empty data
@@ -75,39 +69,10 @@ function Document({
     return null;
   }
 
-  const { title, _type, seo } = publishedData;
-
-  return (
-    <>
-      <Head>
-        <SEO
-          data={{
-            pageTitle: title,
-            type: _type,
-            route: publishedData?.slug,
-            ...seo,
-          }}
-          defaultSeo={defaultSeo}
-        />
-        {/* Structured data (JSON-LD encoding) */}
-        <script
-          key={`${_type}-jsonld`}
-          type="application/ld+json"
-          dangerouslySetInnerHTML={addSEOJsonLd({
-            seo: seo,
-            type: _type,
-            slug: publishedData?.slug,
-            defaults: defaultSeo,
-            pageData: publishedData,
-          })}
-        />
-        <title>{seo?.seoTitle ?? title ?? "WebriQ Studio"}</title>
-      </Head>
-
-      {/*  Show page sections */}
-      {data?.pageData && <PageSections data={publishedData} />}
-    </>
-  );
+  {
+    /*  Show page sections */
+  }
+  return data?.pageData && <PageSections data={publishedData} />;
 }
 
 /**
@@ -118,11 +83,7 @@ function Document({
  *
  * @returns Document with preview data
  */
-function DocumentWithPreview({
-  data,
-  token = null,
-  defaultSeo,
-}: DocumentWithPreviewProps) {
+function DocumentWithPreview({ data, token = null }: DocumentWithPreviewProps) {
   const previewDataEventSource = usePreview(token, homeQuery);
 
   const previewData: PageData =
@@ -133,37 +94,9 @@ function DocumentWithPreview({
     return null;
   }
 
-  const { title, _type, seo } = previewData;
-
   return (
     <>
-      <Head>
-        <SEO
-          data={{
-            pageTitle: title,
-            type: _type,
-            route: previewData?.slug,
-            ...seo,
-          }}
-          defaultSeo={defaultSeo}
-        />
-        {/* Structured data (JSON-LD encoding) */}
-        <script
-          key={`${_type}-jsonld`}
-          type="application/ld+json"
-          dangerouslySetInnerHTML={addSEOJsonLd({
-            seo: seo,
-            type: _type,
-            slug: previewData?.slug,
-            defaults: defaultSeo,
-            pageData: previewData,
-          })}
-        />
-        <title>{seo?.seoTitle ?? title ?? "WebriQ Studio"}</title>
-      </Head>
-
       {/* if no sections, show no sections only in preview */}
-
       {(!previewData ||
         !previewData?.sections ||
         previewData?.sections?.length === 0) && <PreviewNoContent />}
@@ -191,13 +124,39 @@ export const getStaticProps = async ({
   // pass page data and preview to helper function
   const pageData: PageData = filterDataToSingleItem(indexPage, preview);
 
+  const data = { pageData };
+
+  // SEO tags
+  const seo = SEO({
+    data: {
+      title: data?.pageData?.title || "Stackshift | Home page",
+      type: data?.pageData?._type || "page",
+      route: "",
+      ...data?.pageData?.seo,
+    },
+    defaultSeo: globalSEO,
+  });
+
+  // Structured data (JSON-LD encoding)
+  const seoSchema = {
+    key: `${data?.pageData?._type}-jsonld`,
+    innerHTML: addSEOJsonLd({
+      seo: seo,
+      type: data?.pageData?._type,
+      defaults: globalSEO,
+      slug: "",
+      pageData: data?.pageData,
+    }),
+  };
+
   // if our query failed, then return null to display custom no-preview page
   if (!pageData) {
     return {
       props: {
         preview,
         data: { pageData: null },
-        defaultSeo: globalSEO,
+        seo,
+        seoSchema,
       },
     };
   }
@@ -207,8 +166,9 @@ export const getStaticProps = async ({
       preview,
       token: (preview && previewData.token) || "",
       source: (preview && previewData.source) || "",
-      data: { pageData },
-      defaultSeo: globalSEO,
+      data,
+      seo,
+      seoSchema,
     },
   };
 };

--- a/pages/products/[slug].tsx
+++ b/pages/products/[slug].tsx
@@ -14,7 +14,7 @@ import { PreviewBanner } from "components/PreviewBanner";
 import { PreviewNoContent } from "components/PreviewNoContent";
 import { ProductSections } from "components/page/store/products";
 import InlineEditorContextProvider from "context/InlineEditorContext";
-import { CollectionProduct, CommonSections, SeoTags } from "types";
+import { CollectionProduct, CommonSections, SeoTags, SeoSchema } from "types";
 import { addSEOJsonLd } from "components/SEO";
 
 interface ProductPageBySlugProps {
@@ -23,7 +23,7 @@ interface ProductPageBySlugProps {
   token: string;
   source: string;
   seo?: SeoTags[];
-  seoSchema?: any;
+  seoSchema?: SeoSchema;
 }
 
 interface Data {
@@ -156,7 +156,7 @@ export async function getStaticProps({
     data: {
       title: data?.productData?.name || "Stackshift | Product page",
       type: data?.productData?._type || "mainProduct",
-      route: `products/${params?.slug}/`,
+      route: `products/${params?.slug}`,
       ...data?.productData?.seo,
     },
     defaultSeo: globalSEO,

--- a/pages/products/[slug].tsx
+++ b/pages/products/[slug].tsx
@@ -1,7 +1,6 @@
 /** This component displays content for the PRODUCT page */
 
 import React, { useEffect } from "react";
-import Head from "next/head";
 import { useRouter } from "next/router";
 import { groq } from "next-sanity";
 import { PreviewSuspense } from "next-sanity/preview";
@@ -9,12 +8,13 @@ import { sanityClient, getClient } from "lib/sanity.client";
 import { usePreview } from "lib/sanity.preview";
 import { globalSEOQuery, productsQuery } from "pages/api/query";
 import PageNotFound from "pages/404";
-import { filterDataToSingleItem, SEO } from "components/list";
+import { filterDataToSingleItem } from "components/list";
+import { SEO } from "components/SEO";
 import { PreviewBanner } from "components/PreviewBanner";
 import { PreviewNoContent } from "components/PreviewNoContent";
 import { ProductSections } from "components/page/store/products";
 import InlineEditorContextProvider from "context/InlineEditorContext";
-import { CollectionProduct, CommonSections, DefaultSeoData } from "types";
+import { CollectionProduct, CommonSections, SeoTags } from "types";
 import { addSEOJsonLd } from "components/SEO";
 
 interface ProductPageBySlugProps {
@@ -22,7 +22,8 @@ interface ProductPageBySlugProps {
   preview: boolean;
   token: string;
   source: string;
-  defaultSeo: DefaultSeoData;
+  seo?: SeoTags[];
+  seoSchema?: any;
 }
 
 interface Data {
@@ -37,7 +38,6 @@ interface DocumentWithPreviewProps {
   data: Data;
   token: string;
   slug: string | string[];
-  defaultSeo: DefaultSeoData;
 }
 
 function ProductPageBySlug({
@@ -45,7 +45,6 @@ function ProductPageBySlug({
   preview,
   token,
   source,
-  defaultSeo,
 }: ProductPageBySlugProps) {
   const router = useRouter();
   const slug = router.query.slug;
@@ -63,16 +62,14 @@ function ProductPageBySlug({
           <PreviewBanner />
           <PreviewSuspense fallback={"Loading..."}>
             <InlineEditorContextProvider showInlineEditor={showInlineEditor}>
-              <DocumentWithPreview
-                {...{ data, token: token || null, slug, defaultSeo }}
-              />
+              <DocumentWithPreview {...{ data, token: token || null, slug }} />
             </InlineEditorContextProvider>
           </PreviewSuspense>
         </>
       );
     }
 
-    return <Document {...{ data, defaultSeo }} />;
+    return <Document {...{ data }} />;
   }
 }
 
@@ -82,13 +79,7 @@ function ProductPageBySlug({
  *
  * @returns Document with published data
  */
-function Document({
-  data,
-  defaultSeo,
-}: {
-  data: Data;
-  defaultSeo: DefaultSeoData;
-}) {
+function Document({ data }: { data: Data }) {
   const publishedData = data?.productData; // latest published data in Sanity
 
   // General safeguard against empty data
@@ -96,52 +87,7 @@ function Document({
     return null;
   }
 
-  const {
-    commonSections, // sections from Store > Commerce Pages > Products
-    name, // product name
-    seo, // product page SEO
-    _type, // page type
-  } = publishedData;
-
-  const finalSEO = commonSections?.seo ?? seo;
-
-  return (
-    <>
-      <Head>
-        <SEO
-          data={{
-            pageTitle: name,
-            type: _type,
-            route: publishedData?.slug,
-            ...finalSEO,
-          }}
-          defaultSeo={defaultSeo}
-        />
-        <link rel="icon" href="../favicon.ico" />
-        {/* Structured data (JSON-LD encoding) */}
-        <script
-          key={`${_type}-jsonld`}
-          type="application/ld+json"
-          dangerouslySetInnerHTML={addSEOJsonLd({
-            seo: seo,
-            type: _type,
-            slug: publishedData?.slug,
-            defaults: defaultSeo,
-            pageData: publishedData,
-          })}
-        />
-        <title>
-          {seo?.seoTitle ??
-            commonSections?.seo?.seoTitle ??
-            name ??
-            "WebriQ Studio"}
-        </title>
-      </Head>
-
-      {/* Show Product page sections */}
-      {data?.productData && <ProductSections data={publishedData} />}
-    </>
-  );
+  return data?.productData && <ProductSections data={publishedData} />;
 }
 
 /**
@@ -157,7 +103,6 @@ function DocumentWithPreview({
   data,
   slug,
   token = null,
-  defaultSeo,
 }: DocumentWithPreviewProps) {
   // Current drafts data in Sanity
   const previewDataEventSource = usePreview(token, productsQuery, { slug });
@@ -168,48 +113,8 @@ function DocumentWithPreview({
     return null;
   }
 
-  const {
-    commonSections, // sections from Store > Commerce Pages > Products
-    name, // product name
-    seo, // product page SEO
-    _type, // page type
-  } = previewData;
-
-  const finalSEO = commonSections?.seo ?? seo;
-
   return (
     <>
-      <Head>
-        <SEO
-          data={{
-            pageTitle: name,
-            type: _type,
-            route: previewData?.slug,
-            ...finalSEO,
-          }}
-          defaultSeo={defaultSeo}
-        />
-        <link rel="icon" href="../favicon.ico" />
-        {/* Structured data (JSON-LD encoding) */}
-        <script
-          key={`${_type}-jsonld`}
-          type="application/ld+json"
-          dangerouslySetInnerHTML={addSEOJsonLd({
-            seo: seo,
-            type: _type,
-            slug: previewData?.slug,
-            defaults: defaultSeo,
-            pageData: previewData,
-          })}
-        />
-        <title>
-          {seo?.seoTitle ??
-            commonSections?.seo?.seoTitle ??
-            name ??
-            "WebriQ Studio"}
-        </title>
-      </Head>
-
       {/* if no sections, show no sections only in preview */}
       {(!previewData ||
         !previewData?.sections ||
@@ -242,15 +147,41 @@ export async function getStaticProps({
     preview
   );
 
+  const data = {
+    productData: singleProductsData || null,
+  };
+
+  // SEO tags
+  const seo = SEO({
+    data: {
+      title: data?.productData?.name || "Stackshift | Product page",
+      type: data?.productData?._type || "mainProduct",
+      route: `products/${params?.slug}/`,
+      ...data?.productData?.seo,
+    },
+    defaultSeo: globalSEO,
+  });
+
+  // Structured data (JSON-LD encoding)
+  const seoSchema = {
+    key: `${data?.productData?._type}-jsonld`,
+    innerHTML: addSEOJsonLd({
+      seo: seo,
+      type: data?.productData?._type,
+      defaults: globalSEO,
+      slug: params?.slug,
+      pageData: data?.productData,
+    }),
+  };
+
   return {
     props: {
       preview,
       token: (preview && previewData.token) || "",
       source: (preview && previewData.source) || "",
-      data: {
-        productData: singleProductsData || null,
-      },
-      defaultSeo: globalSEO,
+      data,
+      seo,
+      seoSchema,
     },
     // If webhooks isn't setup then attempt to re-generate in 1 minute intervals
     revalidate: process.env.SANITY_REVALIDATE_SECRET ? undefined : 60,
@@ -273,7 +204,7 @@ export async function getStaticPaths() {
   );
 
   return {
-    paths: products?.map((slug) => ({ params: { slug } })),
+    paths: products.map((slug) => ({ params: { slug } })),
     fallback: true,
   };
 }

--- a/types.ts
+++ b/types.ts
@@ -223,10 +223,14 @@ export interface SeoTags {
   href?: string | null;
 }
 
-// TODO
-// export interface SeoSchema {
-
-// }
+export interface SeoSchema {
+  key: string;
+  innerHTML?:
+    | {
+        __html: string | TrustedHTML;
+      }
+    | undefined;
+}
 
 export interface Sections extends SanityBody {
   label?: string;

--- a/types.ts
+++ b/types.ts
@@ -205,6 +205,29 @@ export interface DefaultSeoData {
   defaultSeoImage: SanityImage | undefined;
 }
 
+export interface SeoData extends Seo {
+  title: string; // page title
+  name?: string; // for product page
+  body?: any; // for blog page
+  type: string; // page type e.g. blog
+  route: string | SanitySlug | string[]; // page slug
+}
+
+export interface SeoTags {
+  name?: string | null;
+  title?: string | null;
+  key: string;
+  content?: string | null;
+  property?: string | null;
+  rel?: string | null;
+  href?: string | null;
+}
+
+// TODO
+// export interface SeoSchema {
+
+// }
+
 export interface Sections extends SanityBody {
   label?: string;
   variant?: string;


### PR DESCRIPTION
Expected: SEO Meta tags should be dynamically updated based on current content when navigating between pages
Actual: SEO Meta tags only get updated when the page is refreshed