### PR TITLE
Update studio tool menu based on StackShift revamp

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -48,11 +48,16 @@ export default defineConfig({
     codeInput(), // for "code" schema type
   ],
   tools: (prev) => {
-    // 👇 Uses environment variables set by Vite in development mode
-    if (process.env.NODE_ENV !== "production") {
-      return prev;
+    // 05-28-2024 StackShift revamp 2024: Adding forms and stripe accounts done from StackShift app
+    const hideTools = ["webriq-forms", "payments", "vision"];
+    const isProduction = process.env.NODE_ENV === "production";
+
+    if (!isProduction) {
+      hideTools.pop(); // only show "Vision" in development
+
+      return prev.filter((tool) => !hideTools?.includes(tool.name));
     }
-    return prev.filter((tool) => tool.name !== "vision");
+    return prev.filter((tool) => !hideTools?.includes(tool.name));
   },
   studio: {
     components: {


### PR DESCRIPTION
Parent pull request: https://github.com/webriq-pagebuilder/app/pull/178

For newly created StackShift projects, the studio will display this tool menu:
1. local development (e.g localhost:3000)
![Screen Shot 2024-05-29 at 12 55 06 PM](https://github.com/webriq-pagebuilder/site-template-default/assets/78787873/f5f5eeb1-d1a9-448e-97eb-5fcd378b5d1b)

2. production
![Screen Shot 2024-05-29 at 12 53 27 PM](https://github.com/webriq-pagebuilder/site-template-default/assets/78787873/e0e8016b-60bb-47b0-a632-a68aa7ae88a4)
