### PR TITLE
Hotfix: Links not working

### DIFF
--- a/components/ui/link.tsx
+++ b/components/ui/link.tsx
@@ -26,7 +26,6 @@ export default function LocalLink({
       target={target}
       rel={rel}
       href={href}
-      {...props}
     >
       {children}
     </Link>


### PR DESCRIPTION
Links are not working: returns "/link" even when set properly either as internal or external link from studio