### PR TITLE
Display inline editor on custom pages

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -30,6 +30,8 @@ import { webriqGPT3 } from "@webriq-pagebuilder/sanity-plugin-input-component-gp
 import { webriqComponents } from "@webriq-pagebuilder/sanity-plugin-webriq-components";
 import { webriQInspectorInlineEdit } from "@webriq-pagebuilder/sanity-plugin-inspector-inline-edit";
 
+import customResolvePreviewUrl from "studio/resolvePreviewUrl";
+
 export default defineConfig({
   basePath: "/studio",
   title: NEXT_PUBLIC_SANITY_PROJECT_NAME,
@@ -43,7 +45,12 @@ export default defineConfig({
     webriqPayments(),
     webriqBlog(),
     webriqGPT3(),
-    webriQInspectorInlineEdit(),
+    webriQInspectorInlineEdit({
+      // Append custom document types
+      documentTypes: (defaults) => [...defaults, "themePage"],
+      // Use your existing custom preview URL
+      resolvePreviewUrl: customResolvePreviewUrl,
+    }),
     media(),
     codeInput(), // for "code" schema type
   ],


### PR DESCRIPTION
Extend inline editor support for dynamic pages by updating the plugin to accept custom config (over static definitions).
Pre-requisite (merge): https://github.com/webriq-pagebuilder/sanity-packages/pull/159