### PR TITLE
Connect Newsletter sign-ups with PublishForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ To learn more about Next.js, take a look at the following resources:
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
+## Connecting newsletter signups to PublishForge
+
+If this site is linked to a [PublishForge](https://www.publishforge.cloud) project, `newsletter`
+form submissions can also be added as subscribers in that project's **Newsletter**
+(alongside the normal webriq-forms submission). The link is **optional** — sites without
+a PublishForge simply skip this setup.
+
+This uses the form's built-in **Webhook Settings** (no code, no env change on the site):
+
+1. In Sanity Studio, open the `newsletter` section's form → **Webhook Settings**.
+2. Add the PublishForge ingest URL:
+
+   ```
+   https://<your-publishforge-domain>/api/newsletter/webhook
+   ```
+
+3. In the PublishForge deployment, add the newsletter form's id to
+   `NEWSLETTER_WEBHOOK_FORM_IDS` (comma-separated allowlist).
+
+On submission, the webriq-forms backend POSTs the payload to that URL **after**
+reCAPTCHA passes; PublishForge creates an active subscriber tagged
+`source: stackshift`. The webhook is fire-and-forget — if the endpoint is
+unconfigured or unavailable, the form still submits and redirects exactly as usual.
+
 ## Get in touch with us
 
 Let’s work together on your digital experience project. Check out the [WebriQ](https://www.webriq.com/contact-us) website for more details.

--- a/README.md
+++ b/README.md
@@ -37,22 +37,36 @@ form submissions can also be added as subscribers in that project's **Newsletter
 (alongside the normal webriq-forms submission). The link is **optional** — sites without
 a PublishForge simply skip this setup.
 
-This uses the form's built-in **Webhook Settings** (no code, no env change on the site):
+The webriq-forms webhook can't send auth headers, so submissions are routed through
+a same-origin **relay** ([`pages/api/newsletter-relay.ts`](pages/api/newsletter-relay.ts))
+that attaches the PublishForge ingest key server-side. Setup:
 
-1. In Sanity Studio, open the `newsletter` section's form → **Webhook Settings**.
-2. Add the PublishForge ingest URL:
+1. Set these env vars on this site (server-only — never `NEXT_PUBLIC_`):
 
    ```
-   https://<your-publishforge-domain>/api/newsletter/webhook
+   PF_NEWSLETTER_INGEST_URL=https://<your-publishforge-domain>/api/newsletter/webhook
+   PF_NEWSLETTER_INGEST_KEY=<shared key, must match PublishForge's NEWSLETTER_INGEST_KEY>
    ```
 
-3. In the PublishForge deployment, add the newsletter form's id to
-   `NEWSLETTER_WEBHOOK_FORM_IDS` (comma-separated allowlist).
+   Leave them unset and the relay is a safe no-op (site not linked).
 
-On submission, the webriq-forms backend POSTs the payload to that URL **after**
-reCAPTCHA passes; PublishForge creates an active subscriber tagged
-`source: stackshift`. The webhook is fire-and-forget — if the endpoint is
-unconfigured or unavailable, the form still submits and redirects exactly as usual.
+2. In the StackShift App, open the project → gear icon → **Forms** → the newsletter
+   form → its settings → **Webhook Settings**, and set the webhook URL to this site's
+   relay:
+
+   ```
+   https://<this-site-domain>/api/newsletter-relay
+   ```
+
+3. In the PublishForge deployment, set `NEWSLETTER_INGEST_KEY` (same value as above)
+   and, optionally, add the newsletter form's id to `NEWSLETTER_WEBHOOK_FORM_IDS`
+   (comma-separated allowlist).
+
+On submission, the webriq-forms backend POSTs the payload to the relay **after**
+reCAPTCHA passes; the relay forwards it to PublishForge with the Bearer key, and
+PublishForge creates an active subscriber tagged `source: stackshift`. The whole path
+is fire-and-forget — if the relay or PublishForge is unconfigured or unavailable, the
+form still submits and redirects exactly as usual.
 
 ## Get in touch with us
 

--- a/pages/api/newsletter-relay.ts
+++ b/pages/api/newsletter-relay.ts
@@ -1,0 +1,53 @@
+/**
+ * Newsletter subscribe relay → PublishForge.
+ *
+ * The webriq-forms webhook for the `newsletter` form is pointed at this same-origin
+ * route. webriq webhooks cannot send custom headers or be signed, so this server-side
+ * relay holds the PublishForge ingest key (server env, never the browser/URL) and
+ * forwards the submission to PublishForge with an `Authorization: Bearer` header.
+ *
+ * Optional: if PF_NEWSLETTER_INGEST_URL / PF_NEWSLETTER_INGEST_KEY are unset, this
+ * site is not linked to a PublishForge — the relay is a safe no-op.
+ *
+ * Fire-and-forget: always responds 2xx so the webriq webhook is never retried, and
+ * this has no bearing on the visitor's original form submission.
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "POST method only" });
+  }
+
+  const url = process.env.PF_NEWSLETTER_INGEST_URL;
+  const key = process.env.PF_NEWSLETTER_INGEST_KEY;
+
+  // Not linked to a PublishForge — accept and ignore.
+  if (!url || !key) {
+    return res.status(200).json({ ok: true, ignored: "publishforge not linked" });
+  }
+
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+        // Forward the originating site so PublishForge can tag metadata.site.
+        referer:
+          (req.headers.referer as string) ||
+          process.env.NEXT_PUBLIC_SITE_URL ||
+          "",
+      },
+      body: JSON.stringify(req.body ?? {}),
+    });
+  } catch (error) {
+    // Never fail the webhook over a relay/PublishForge hiccup.
+    console.error("Newsletter relay error:", error);
+  }
+
+  return res.status(200).json({ ok: true });
+}

--- a/pages/api/newsletter-relay.ts
+++ b/pages/api/newsletter-relay.ts
@@ -31,7 +31,7 @@ export default async function handler(
   }
 
   try {
-    await fetch(url, {
+    const pfRes = await fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -44,6 +44,14 @@ export default async function handler(
       },
       body: JSON.stringify(req.body ?? {}),
     });
+    // A non-2xx PublishForge response (e.g. 401 = ingest key mismatch, 503 =
+    // PF not configured) does not throw — log it so the failure is visible
+    // instead of silently swallowed. Still respond 2xx to the form/webhook.
+    if (!pfRes.ok) {
+      console.error(
+        `Newsletter relay: PublishForge responded ${pfRes.status} ${pfRes.statusText}`
+      );
+    }
   } catch (error) {
     // Never fail the webhook over a relay/PublishForge hiccup.
     console.error("Newsletter relay error:", error);


### PR DESCRIPTION
If a StackShift project is linked to a PublishForge, `newsletter` component form submissions can also be added as subscribers in that project's **Newsletter** (alongside the normal webriq-forms submission). The link is **optional** — sites without a PublishForge simply skip this setup.